### PR TITLE
Handle authentication errors without crash; add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "larrykluger/docusign-lib",
+    "description": "DocuSign eSign PHP Client Library",
+    "authors": [
+        {
+            "name": "DocuSign"
+        }
+    ],
+    "autoload": {
+        "files": [
+            "src/DocuSign_Client.php"
+        ]
+    }
+}

--- a/src/io/DocuSign_CurlIO.php
+++ b/src/io/DocuSign_CurlIO.php
@@ -67,8 +67,11 @@ class DocuSign_CurlIO extends DocuSign_IO {
 		curl_close($curl);
 
 		if (is_array($response) && array_key_exists('errorCode', $response)) {
+			throw new DocuSign_IOException($response['errorCode'] . ': ' . $response['message']);
+		} elseif (get_class($response) === 'stdClass' && property_exists($response, 'errorCode')) {
 			throw new DocuSign_IOException($response->errorCode . ': ' . $response->message);
 		}
+
 
 		return $response;
 	}

--- a/src/io/DocuSign_CurlIO.php
+++ b/src/io/DocuSign_CurlIO.php
@@ -67,6 +67,8 @@ class DocuSign_CurlIO extends DocuSign_IO {
 		curl_close($curl);
 
 		if (is_array($response) && array_key_exists('errorCode', $response)) {
+			throw new DocuSign_IOException($response['errorCode'] . ': ' . $response['message']);
+		} elseif (get_class($response) === 'stdClass' && property_exists($response, 'errorCode')) {
 			throw new DocuSign_IOException($response->errorCode . ': ' . $response->message);
 		}
 

--- a/src/io/DocuSign_CurlIO.php
+++ b/src/io/DocuSign_CurlIO.php
@@ -67,11 +67,8 @@ class DocuSign_CurlIO extends DocuSign_IO {
 		curl_close($curl);
 
 		if (is_array($response) && array_key_exists('errorCode', $response)) {
-			throw new DocuSign_IOException($response['errorCode'] . ': ' . $response['message']);
-		} elseif (get_class($response) === 'stdClass' && property_exists($response, 'errorCode')) {
 			throw new DocuSign_IOException($response->errorCode . ': ' . $response->message);
 		}
-
 
 		return $response;
 	}


### PR DESCRIPTION
Hi,

Please consider this pull request. It makes two changes:

1. Add a composer.json file to the project. This enables Composer to be used with the sw.

2. There is a bug when incorrect user name/pw are sent via the client library. The error response comes back as a JSON object, not as an array. Result: code crashes. My change enables the bad authentication response to be handled correctly.

Thanks,

Larry Kluger 
DocuSign TLV office