### PR TITLE
Update DocuSign_CurlIO.php

### DIFF
--- a/src/io/DocuSign_CurlIO.php
+++ b/src/io/DocuSign_CurlIO.php
@@ -68,8 +68,6 @@ class DocuSign_CurlIO extends DocuSign_IO {
 
 		if (is_array($response) && array_key_exists('errorCode', $response)) {
 			throw new DocuSign_IOException($response['errorCode'] . ': ' . $response['message']);
-		} elseif (get_class($response) === 'stdClass' && property_exists($response, 'errorCode')) {
-			throw new DocuSign_IOException($response->errorCode . ': ' . $response->message);
 		}
 
 		return $response;


### PR DESCRIPTION
fix for error "get_class() expects parameter 1 to be object, string given"