### PR TITLE
Fix PHP parse errors in AccountsApi

### DIFF
--- a/src/Api/AccountsApi.php
+++ b/src/Api/AccountsApi.php
@@ -768,9 +768,9 @@ class AccountsApi
      * @throws \DocuSign\eSign\ApiException on non-2xx response
      * @return \DocuSign\eSign\Model\NewAccountSummary
      */
-    public function create($new_account_definition = nullAccountsApi\CreateOptions $options = null)
+    public function create($new_account_definition = null, AccountsApi\CreateOptions $options = null)
     {
-        list($response) = $this->createWithHttpInfo($new_account_definition$options);
+        list($response) = $this->createWithHttpInfo($new_account_definition, $options);
         return $response;
     }
 
@@ -784,7 +784,7 @@ class AccountsApi
      * @throws \DocuSign\eSign\ApiException on non-2xx response
      * @return array of \DocuSign\eSign\Model\NewAccountSummary, HTTP status code, HTTP response headers (array of strings)
      */
-    public function createWithHttpInfo($new_account_definition = nullAccountsApi\CreateOptions $options = null)
+    public function createWithHttpInfo($new_account_definition = null, AccountsApi\CreateOptions $options = null)
     {
         // parse inputs
         $resourcePath = "/v2/accounts";


### PR DESCRIPTION
Hey DocuSign team,
I'm not sure how this one slipped through, but the entire AccountsApi is broken due to a parse error. I see your team used a generator to create the classes, and it seems there was something wrong that caused a comma to be missed in two of the class methods. This has broken the whole AccountsApi class.

I've gone ahead and fixed the methods, which fixes all Accounts related API calls. I'm assuming this will need to be fixed in your generator as well.

This is pretty high priority, as a large chunk of the API is completely broken in the 3.0.0 release.