### PR TITLE
Fixes #38 DateTime error when getting a template

### DIFF
--- a/src/Model/Tabs.php
+++ b/src/Model/Tabs.php
@@ -58,7 +58,7 @@ class Tabs implements ArrayAccess
         'checkbox_tabs' => '\DocuSign\eSign\Model\Checkbox[]',
         'company_tabs' => '\DocuSign\eSign\Model\Company[]',
         'date_signed_tabs' => '\DocuSign\eSign\Model\DateSigned[]',
-        'date_tabs' => '\DocuSign\eSign\Model\\DateTime[]',
+        'date_tabs' => '\DocuSign\eSign\Model\\Date[]',
         'decline_tabs' => '\DocuSign\eSign\Model\Decline[]',
         'email_address_tabs' => '\DocuSign\eSign\Model\EmailAddress[]',
         'email_tabs' => '\DocuSign\eSign\Model\Email[]',


### PR DESCRIPTION
Fixes #38 Updating deprecated \DocuSign\eSign\Model\DateTime to \DocuSign\eSign\Model\Date

https://github.com/docusign/docusign-php-client/issues/38