### PR TITLE
Removed references to '\DocuSign\eSign\Model\OfflineAttributes'

### DIFF
--- a/src/Model/InPersonSigner.php
+++ b/src/Model/InPersonSigner.php
@@ -82,7 +82,6 @@ class InPersonSigner implements ArrayAccess
         'name' => 'string',
         'notary_host' => '\DocuSign\eSign\Model\NotaryHost',
         'note' => 'string',
-        'offline_attributes' => '\DocuSign\eSign\Model\OfflineAttributes',
         'phone_authentication' => '\DocuSign\eSign\Model\RecipientPhoneAuthentication',
         'recipient_attachments' => '\DocuSign\eSign\Model\RecipientAttachment[]',
         'recipient_authentication_status' => '\DocuSign\eSign\Model\AuthenticationStatus',
@@ -153,7 +152,6 @@ class InPersonSigner implements ArrayAccess
         'name' => 'name',
         'notary_host' => 'notaryHost',
         'note' => 'note',
-        'offline_attributes' => 'offlineAttributes',
         'phone_authentication' => 'phoneAuthentication',
         'recipient_attachments' => 'recipientAttachments',
         'recipient_authentication_status' => 'recipientAuthenticationStatus',
@@ -220,7 +218,6 @@ class InPersonSigner implements ArrayAccess
         'name' => 'setName',
         'notary_host' => 'setNotaryHost',
         'note' => 'setNote',
-        'offline_attributes' => 'setOfflineAttributes',
         'phone_authentication' => 'setPhoneAuthentication',
         'recipient_attachments' => 'setRecipientAttachments',
         'recipient_authentication_status' => 'setRecipientAuthenticationStatus',
@@ -287,7 +284,6 @@ class InPersonSigner implements ArrayAccess
         'name' => 'getName',
         'notary_host' => 'getNotaryHost',
         'note' => 'getNote',
-        'offline_attributes' => 'getOfflineAttributes',
         'phone_authentication' => 'getPhoneAuthentication',
         'recipient_attachments' => 'getRecipientAttachments',
         'recipient_authentication_status' => 'getRecipientAuthenticationStatus',
@@ -379,7 +375,6 @@ class InPersonSigner implements ArrayAccess
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['notary_host'] = isset($data['notary_host']) ? $data['notary_host'] : null;
         $this->container['note'] = isset($data['note']) ? $data['note'] : null;
-        $this->container['offline_attributes'] = isset($data['offline_attributes']) ? $data['offline_attributes'] : null;
         $this->container['phone_authentication'] = isset($data['phone_authentication']) ? $data['phone_authentication'] : null;
         $this->container['recipient_attachments'] = isset($data['recipient_attachments']) ? $data['recipient_attachments'] : null;
         $this->container['recipient_authentication_status'] = isset($data['recipient_authentication_status']) ? $data['recipient_authentication_status'] : null;
@@ -1019,27 +1014,6 @@ class InPersonSigner implements ArrayAccess
     public function setNote($note)
     {
         $this->container['note'] = $note;
-
-        return $this;
-    }
-
-    /**
-     * Gets offline_attributes
-     * @return \DocuSign\eSign\Model\OfflineAttributes
-     */
-    public function getOfflineAttributes()
-    {
-        return $this->container['offline_attributes'];
-    }
-
-    /**
-     * Sets offline_attributes
-     * @param \DocuSign\eSign\Model\OfflineAttributes $offline_attributes
-     * @return $this
-     */
-    public function setOfflineAttributes($offline_attributes)
-    {
-        $this->container['offline_attributes'] = $offline_attributes;
 
         return $this;
     }

--- a/src/Model/Signer.php
+++ b/src/Model/Signer.php
@@ -86,7 +86,6 @@ class Signer implements ArrayAccess
         'last_name' => 'string',
         'name' => 'string',
         'note' => 'string',
-        'offline_attributes' => '\DocuSign\eSign\Model\OfflineAttributes',
         'phone_authentication' => '\DocuSign\eSign\Model\RecipientPhoneAuthentication',
         'recipient_attachments' => '\DocuSign\eSign\Model\RecipientAttachment[]',
         'recipient_authentication_status' => '\DocuSign\eSign\Model\AuthenticationStatus',
@@ -159,7 +158,6 @@ class Signer implements ArrayAccess
         'last_name' => 'lastName',
         'name' => 'name',
         'note' => 'note',
-        'offline_attributes' => 'offlineAttributes',
         'phone_authentication' => 'phoneAuthentication',
         'recipient_attachments' => 'recipientAttachments',
         'recipient_authentication_status' => 'recipientAuthenticationStatus',
@@ -228,7 +226,6 @@ class Signer implements ArrayAccess
         'last_name' => 'setLastName',
         'name' => 'setName',
         'note' => 'setNote',
-        'offline_attributes' => 'setOfflineAttributes',
         'phone_authentication' => 'setPhoneAuthentication',
         'recipient_attachments' => 'setRecipientAttachments',
         'recipient_authentication_status' => 'setRecipientAuthenticationStatus',
@@ -297,7 +294,6 @@ class Signer implements ArrayAccess
         'last_name' => 'getLastName',
         'name' => 'getName',
         'note' => 'getNote',
-        'offline_attributes' => 'getOfflineAttributes',
         'phone_authentication' => 'getPhoneAuthentication',
         'recipient_attachments' => 'getRecipientAttachments',
         'recipient_authentication_status' => 'getRecipientAuthenticationStatus',
@@ -391,7 +387,6 @@ class Signer implements ArrayAccess
         $this->container['last_name'] = isset($data['last_name']) ? $data['last_name'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['note'] = isset($data['note']) ? $data['note'] : null;
-        $this->container['offline_attributes'] = isset($data['offline_attributes']) ? $data['offline_attributes'] : null;
         $this->container['phone_authentication'] = isset($data['phone_authentication']) ? $data['phone_authentication'] : null;
         $this->container['recipient_attachments'] = isset($data['recipient_attachments']) ? $data['recipient_attachments'] : null;
         $this->container['recipient_authentication_status'] = isset($data['recipient_authentication_status']) ? $data['recipient_authentication_status'] : null;
@@ -1113,27 +1108,6 @@ class Signer implements ArrayAccess
     public function setNote($note)
     {
         $this->container['note'] = $note;
-
-        return $this;
-    }
-
-    /**
-     * Gets offline_attributes
-     * @return \DocuSign\eSign\Model\OfflineAttributes
-     */
-    public function getOfflineAttributes()
-    {
-        return $this->container['offline_attributes'];
-    }
-
-    /**
-     * Sets offline_attributes
-     * @param \DocuSign\eSign\Model\OfflineAttributes $offline_attributes
-     * @return $this
-     */
-    public function setOfflineAttributes($offline_attributes)
-    {
-        $this->container['offline_attributes'] = $offline_attributes;
 
         return $this;
     }

--- a/src/Model/Witness.php
+++ b/src/Model/Witness.php
@@ -86,7 +86,6 @@ class Witness implements ArrayAccess
         'last_name' => 'string',
         'name' => 'string',
         'note' => 'string',
-        'offline_attributes' => '\DocuSign\eSign\Model\OfflineAttributes',
         'phone_authentication' => '\DocuSign\eSign\Model\RecipientPhoneAuthentication',
         'recipient_attachments' => '\DocuSign\eSign\Model\RecipientAttachment[]',
         'recipient_authentication_status' => '\DocuSign\eSign\Model\AuthenticationStatus',
@@ -161,7 +160,6 @@ class Witness implements ArrayAccess
         'last_name' => 'lastName',
         'name' => 'name',
         'note' => 'note',
-        'offline_attributes' => 'offlineAttributes',
         'phone_authentication' => 'phoneAuthentication',
         'recipient_attachments' => 'recipientAttachments',
         'recipient_authentication_status' => 'recipientAuthenticationStatus',
@@ -232,7 +230,6 @@ class Witness implements ArrayAccess
         'last_name' => 'setLastName',
         'name' => 'setName',
         'note' => 'setNote',
-        'offline_attributes' => 'setOfflineAttributes',
         'phone_authentication' => 'setPhoneAuthentication',
         'recipient_attachments' => 'setRecipientAttachments',
         'recipient_authentication_status' => 'setRecipientAuthenticationStatus',
@@ -303,7 +300,6 @@ class Witness implements ArrayAccess
         'last_name' => 'getLastName',
         'name' => 'getName',
         'note' => 'getNote',
-        'offline_attributes' => 'getOfflineAttributes',
         'phone_authentication' => 'getPhoneAuthentication',
         'recipient_attachments' => 'getRecipientAttachments',
         'recipient_authentication_status' => 'getRecipientAuthenticationStatus',
@@ -399,7 +395,6 @@ class Witness implements ArrayAccess
         $this->container['last_name'] = isset($data['last_name']) ? $data['last_name'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['note'] = isset($data['note']) ? $data['note'] : null;
-        $this->container['offline_attributes'] = isset($data['offline_attributes']) ? $data['offline_attributes'] : null;
         $this->container['phone_authentication'] = isset($data['phone_authentication']) ? $data['phone_authentication'] : null;
         $this->container['recipient_attachments'] = isset($data['recipient_attachments']) ? $data['recipient_attachments'] : null;
         $this->container['recipient_authentication_status'] = isset($data['recipient_authentication_status']) ? $data['recipient_authentication_status'] : null;
@@ -1123,27 +1118,6 @@ class Witness implements ArrayAccess
     public function setNote($note)
     {
         $this->container['note'] = $note;
-
-        return $this;
-    }
-
-    /**
-     * Gets offline_attributes
-     * @return \DocuSign\eSign\Model\OfflineAttributes
-     */
-    public function getOfflineAttributes()
-    {
-        return $this->container['offline_attributes'];
-    }
-
-    /**
-     * Sets offline_attributes
-     * @param \DocuSign\eSign\Model\OfflineAttributes $offline_attributes
-     * @return $this
-     */
-    public function setOfflineAttributes($offline_attributes)
-    {
-        $this->container['offline_attributes'] = $offline_attributes;
 
         return $this;
     }


### PR DESCRIPTION
Bugfix for a deserialization issue where the following classes contained references in their `$swaggerTypes` array to `\DocuSign\eSign\Model\OfflineAttributes`, but the class is no longer present in v4.

For classes:

- `\DocuSign\eSign\Model\InPersonSigner.php`
- `\DocuSign\eSign\Model\Signer.php`
- `\DocuSign\eSign\Model\Wintness.php`

Removed references relating to `\DocuSign\eSign\Model\OfflineAttributes`.